### PR TITLE
Make child links respect the child `internal` attr

### DIFF
--- a/lib/guides_style_18f/includes/sidebar.html
+++ b/lib/guides_style_18f/includes/sidebar.html
@@ -16,7 +16,7 @@
                 aria-hidden="{% if link.text == page.parent or link.text == page.title %}false{% else %}true{% endif %}">
               {% for child in link.children %}
                 <li class="{% if page.title == child.text %}sidebar-nav-active{% endif %}">
-                  <a href="{% if link.internal == true %}{{ site.baseurl }}/{{ link.url }}{% endif %}{{ child.url }}"  
+                  <a href="{% if child.internal == true %}{{ site.baseurl }}/{{ link.url }}{% endif %}{{ child.url }}"
                     title="{% if page.title == child.text %}Current Page
                           {% else %}{{ child.text }}{% endif %}">{{ child.text }}</a>
                 </li>


### PR DESCRIPTION
... not the parent's

This should really have a test, but the only way I can see to do that is to move the URL forming logic from templates into code, and that's a bigger change than I want to make right now/ without @mbland weighing in.