### PR TITLE
Fix scroll bug on sidebar navigation

### DIFF
--- a/lib/guides_style_18f/sass/_guides_style_18f_main.scss
+++ b/lib/guides_style_18f/sass/_guides_style_18f_main.scss
@@ -214,7 +214,7 @@ Navigation
     font-size: 14px;
     max-height: 0;
     opacity: 0;
-    overflow: scroll;
+    overflow: auto;
     position: relative;
     -webkit-transition: max-height .2s, opacity .2s;
     -moz-transition: max-height .2s, opacity .2s;


### PR DESCRIPTION
This changes the overflow to auto to prevent the scroll bar from appearing in the sidenav.

Fixes this: https://github.com/18F/methods/pull/71#issuecomment-150339342