### PR TITLE
Integrate us_web_design_standards

### DIFF
--- a/guides-style-18f.gemspec
+++ b/guides-style-18f.gemspec
@@ -22,15 +22,9 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files -z *.md lib assets`.split("\x0")
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename f }
 
-<<<<<<< HEAD
-  s.add_runtime_dependency 'jekyll', '~> 2.5'
-  s.add_runtime_dependency 'sass', '~> 3.4'
-  s.add_runtime_dependency 'rouge', '~> 1.9'
-=======
   s.add_runtime_dependency 'jekyll'
   s.add_runtime_dependency 'sass'
   s.add_runtime_dependency 'rouge'
->>>>>>> 676fa192e774c9d0578372da4aa41b83a4275836
   s.add_runtime_dependency 'us_web_design_standards'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'minitest'

--- a/guides-style-18f.gemspec
+++ b/guides-style-18f.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'jekyll', '~> 2.5'
   s.add_runtime_dependency 'sass', '~> 3.4'
   s.add_runtime_dependency 'rouge', '~> 1.9'
+  s.add_runtime_dependency 'us_web_design_standards'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'codeclimate-test-reporter'

--- a/lib/guides_style_18f/generator.rb
+++ b/lib/guides_style_18f/generator.rb
@@ -1,6 +1,7 @@
 # @author Mike Bland (michael.bland@gsa.gov)
 
 require 'jekyll'
+require 'us_web_design_standards'
 
 module GuidesStyle18F
   class Generator < ::Jekyll::Generator

--- a/lib/guides_style_18f/includes/footer.html
+++ b/lib/guides_style_18f/includes/footer.html
@@ -1,5 +1,5 @@
-<footer role="contentinfo">
-  <div class="wrap">
+<footer class="site-footer" role="contentinfo">
+  <div class="usa-grid">
     <p>This project is maintained by <a href="{{ site.author.url }}">{{ site.author.name }}</a>.</p>
 
     <p>Hosted on <a href="https://github.com/18F/pages/">18F Pages</a>.

--- a/lib/guides_style_18f/includes/sidebar.html
+++ b/lib/guides_style_18f/includes/sidebar.html
@@ -1,22 +1,22 @@
-<aside>
+<aside class="usa-width-one-third">
   <p class="intro">{{ site.subtitle }}</p>
-  <a class="skip-link visuallyhidden focusable" href="#main">Skip to Main Content</a>
   <nav class="sidebar-nav" role="navigation">
-    <ul>
+    <ul class="usa-sidenav-list">
       {% for link in site.navigation %}
         <li class="group {% if page.title == link.text %}sidebar-nav-active{% endif %}">
-          <a href="{% if link.internal == true %}{{ site.baseurl }}/{% endif %}{{ link.url }}"  
+          <a class="{% if page.title == link.text %}usa-current{% endif %}" href="{% if link.internal == true %}{{ site.baseurl }}/{% endif %}{{ link.url }}"  
             title="{% if page.title == link.text %}Current Page
                   {% else %}{{ link.text }}{% endif %}">{{ link.text }}</a>
           {% if link.children %}
             <button class="expand-subnav"
                     aria-expanded="{% if link.text == page.parent or link.text == page.title %}true{% else %}false{% endif %}"
                     aria-controls="nav-collapsible-{{ forloop.index }}">+</button>
-            <ul class="nav-children" id="nav-collapsible-{{ forloop.index }}" 
+            <ul class="usa-sidenav-sub_list" id="nav-collapsible-{{ forloop.index }}" 
                 aria-hidden="{% if link.text == page.parent or link.text == page.title %}false{% else %}true{% endif %}">
               {% for child in link.children %}
                 <li class="{% if page.title == child.text %}sidebar-nav-active{% endif %}">
-                  <a href="{% if child.internal == true %}{{ site.baseurl }}/{{ link.url }}{% endif %}{{ child.url }}"
+                  <a class="{% if page.title == child.text %}usa-current
+                          {% else %}{{ child.text }}{% endif %}" href="{% if child.internal == true %}{{ site.baseurl }}/{{ link.url }}{% endif %}{{ child.url }}"
                     title="{% if page.title == child.text %}Current Page
                           {% else %}{{ child.text }}{% endif %}">{{ child.text }}</a>
                 </li>

--- a/lib/guides_style_18f/includes/sidebar.html
+++ b/lib/guides_style_18f/includes/sidebar.html
@@ -4,7 +4,7 @@
     <ul class="usa-sidenav-list">
       {% for link in site.navigation %}
         <li class="group {% if page.title == link.text %}sidebar-nav-active{% endif %}">
-          <a class="{% if page.title == link.text %}usa-current{% endif %}" href="{% if link.internal == true %}{{ site.baseurl }}/{% endif %}{{ link.url }}"  
+          <a class="{% if page.title == link.text or page.parent == link.text %}usa-current{% endif %}" href="{% if link.internal == true %}{{ site.baseurl }}/{% endif %}{{ link.url }}"  
             title="{% if page.title == link.text %}Current Page
                   {% else %}{{ link.text }}{% endif %}">{{ link.text }}</a>
           {% if link.children %}
@@ -15,8 +15,7 @@
                 aria-hidden="{% if link.text == page.parent or link.text == page.title %}false{% else %}true{% endif %}">
               {% for child in link.children %}
                 <li class="{% if page.title == child.text %}sidebar-nav-active{% endif %}">
-                  <a class="{% if page.title == child.text %}usa-current
-                          {% else %}{{ child.text }}{% endif %}" href="{% if child.internal == true %}{{ site.baseurl }}/{{ link.url }}{% endif %}{{ child.url }}"
+                  <a class="{% if page.title == child.text %}usa-current{% endif %}" href="{% if child.internal == true %}{{ site.baseurl }}/{{ link.url }}{% endif %}{{ child.url }}"
                     title="{% if page.title == child.text %}Current Page
                           {% else %}{{ child.text }}{% endif %}">{{ child.text }}</a>
                 </li>

--- a/lib/guides_style_18f/layouts/default.html
+++ b/lib/guides_style_18f/layouts/default.html
@@ -4,29 +4,34 @@
   {% guides_style_18f_include header.html %}
 
   <body>
+    <a class="skipnav" href="#main">Skip to Main Content</a>
 
     <div class="container">
 
-      <header role="banner">
+      <header class="site-header" role="banner">
 
-        <div class="wrap">
+        <div class="usa-grid">
           {% if site.logourl != null %}
-            <a href="{{ site.author.url }}"><img class="logo" src="{{ site.baseurl }}{{ site.logourl }}" alt="{{ site.logoalt }}" width="75px"></a>
+            <a href="{{ site.author.url }}"><img class="logo" src="{{ site.baseurl }}{{ site.logourl }}" alt="{{ site.logoalt }}"></a>
           {% endif %}
-          <h1 class="site-title"><a class="title-link" href="{{ site.baseurl }}/">{{ site.name }}</a></h1>{% if site.back_link %}
-          <div class="back-link"><a href="{{ site.back_link.url }}">&laquo; {{ site.back_link.text }}</a></div>{% endif %}
+          <h1 class="site-title">
+            <a class="site-title-link" href="{{ site.baseurl }}/">{{ site.name }}</a>
+          </h1>{% if site.back_link %}
+          <div class="back-link">
+            <a href="{{ site.back_link.url }}">&laquo; {{ site.back_link.text }}</a>
+          </div>{% endif %}
         </div>
         
       </header>
 
-      <div class="wrap content">
+      <div class="usa-grid">
 
-        <section id="main" class="main-content" role="main">
+        {% guides_style_18f_include sidebar.html %}
+
+        <section class="main-content usa-width-two-thirds" id="main" role="main">
           <h1>{{ page.title }}</h1>
           {{ content }}
         </section>
-
-        {% guides_style_18f_include sidebar.html %}
 
       </div><!-- /.wrap content -->
 

--- a/lib/guides_style_18f/sass.rb
+++ b/lib/guides_style_18f/sass.rb
@@ -1,6 +1,7 @@
 # @author Mike Bland (michael.bland@gsa.gov)
 
 require 'sass'
+require 'us_web_design_standards'
 
 module GuidesStyle18F
   class Sass

--- a/lib/guides_style_18f/sass/_guides_style_18f_custom-old.scss
+++ b/lib/guides_style_18f/sass/_guides_style_18f_custom-old.scss
@@ -1,0 +1,50 @@
+/*
+This is where custom styles for your guide should live.
+*/
+
+div.skip-nav a {
+  position: absolute;
+  left: -10000;
+  top: 0;
+  width: 1px;
+  height: auto;
+  overflow: hidden;
+}
+div.skip-nav a:focus {
+	position: absolute;
+	top: 5px;
+	left: 5px;
+	width: auto; 
+	height: auto;
+	z-index: 999999;
+	background-color: white;
+	padding-left: 2px;
+	padding-right: 2px;
+	overflow: visible;
+ }
+
+ .mainContent:focus {
+ 	outline: none;
+ }
+
+ table, th, td {
+   border: 1px solid black;
+   padding: 5px;
+   margin:5px;
+}
+th {
+	background: #767576;
+	color:white;
+}
+li.active > a{
+	background-color: #317ab9;
+}
+
+div.back-link {
+	display: block;
+  padding-top: .5em;
+}
+
+header {
+  padding-bottom: 1.5em;
+}

--- a/lib/guides_style_18f/sass/_guides_style_18f_custom.scss
+++ b/lib/guides_style_18f/sass/_guides_style_18f_custom.scss
@@ -1,6 +1,5 @@
 /* Custom styles */
 
-<<<<<<< HEAD
 // Header ------------- //
 
 .site-header {
@@ -90,12 +89,4 @@
   background-color: $color-gray-lightest;
   padding-bottom: 1rem;
   padding-top: 1rem;
-=======
-.site-title {
-  font-size: $h3-font-size;
-}
-
-body {
-  background: pink !important;
->>>>>>> 676fa192e774c9d0578372da4aa41b83a4275836
 }

--- a/lib/guides_style_18f/sass/_guides_style_18f_custom.scss
+++ b/lib/guides_style_18f/sass/_guides_style_18f_custom.scss
@@ -1,9 +1,92 @@
 /* Custom styles */
 
-.site-title {
-  font-size: $h3-font-size;
+// Header ------------- //
+
+.site-header {
+  border-bottom: 4px solid #1188ff;
+  padding: 2em 0;
 }
 
-body {
-  background: pink !important;
+.logo {
+  max-width: 7.5rem;
+
+  @include media($medium-screen) {
+    float: right;
+    max-width: 6rem;
+  }
+}
+
+.site-title {
+  display: inline-block;
+  font-size: $h2-font-size;
+  margin-top: 0;
+
+  a {
+    color: $color-base;
+  }
+}
+
+// Sidebar navigation --------- //
+
+.sidebar-nav {
+  @include media($medium-screen) {
+    margin-top: 6rem;
+  }
+}
+.usa-sidenav-list li {
+  position: relative;
+}
+
+.usa-sidenav-list a {
+  padding-bottom: 1.3rem;
+  padding-top: 1.3rem;
+}
+
+.expand-subnav {
+  background: none;
+  border: none;
+  border-radius: 30px;
+  color: #0072ce;
+  cursor: pointer;
+  display: block;
+  float: right;
+  font-size: 20px;
+  height: 30px;
+  line-height: 1;
+  margin: 8px;
+  padding: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 30px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -o-appearance: none;
+  appearance: none;    
+  -webkit-transition: -webkit-transform .2s;
+  -moz-transition: -moz-transform .2s;
+  -o-transition: -o-transform .2s;
+  transition: transform .2s;
+}
+
+.expand-subnav:hover,
+.expand-subnav:focus {
+  background-color: #0072ce;
+  color: #fff;
+  outline: none;
+}
+
+.expand-subnav[aria-expanded=true] {
+  -webkit-transform: rotate(45deg);
+  -moz-transform: rotate(45deg);
+  -o-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+// Footer ------------ //
+
+.site-footer {
+  background-color: $color-gray-lightest;
+  padding-bottom: 1rem;
+  padding-top: 1rem;
 }

--- a/lib/guides_style_18f/sass/_guides_style_18f_custom.scss
+++ b/lib/guides_style_18f/sass/_guides_style_18f_custom.scss
@@ -1,50 +1,9 @@
-/*
-This is where custom styles for your guide should live.
-*/
+/* Custom styles */
 
-div.skip-nav a {
-  position: absolute;
-  left: -10000;
-  top: 0;
-  width: 1px;
-  height: auto;
-  overflow: hidden;
-}
-div.skip-nav a:focus {
-	position: absolute;
-	top: 5px;
-	left: 5px;
-	width: auto; 
-	height: auto;
-	z-index: 999999;
-	background-color: white;
-	padding-left: 2px;
-	padding-right: 2px;
-	overflow: visible;
- }
-
- .mainContent:focus {
- 	outline: none;
- }
-
- table, th, td {
-   border: 1px solid black;
-   padding: 5px;
-   margin:5px;
-}
-th {
-	background: #767576;
-	color:white;
-}
-li.active > a{
-	background-color: #317ab9;
+.site-title {
+  font-size: $h3-font-size;
 }
 
-div.back-link {
-	display: block;
-  padding-top: .5em;
-}
-
-header {
-  padding-bottom: 1.5em;
+body {
+  background: pink !important;
 }

--- a/lib/guides_style_18f/sass/_guides_style_18f_custom.scss
+++ b/lib/guides_style_18f/sass/_guides_style_18f_custom.scss
@@ -87,6 +87,12 @@
   transform: rotate(45deg);
 }
 
+// Main content ------- //
+
+.main-content {
+  padding-bottom: 4rem;
+}
+
 // Footer ------------ //
 
 .site-footer {

--- a/lib/guides_style_18f/sass/_guides_style_18f_custom.scss
+++ b/lib/guides_style_18f/sass/_guides_style_18f_custom.scss
@@ -26,6 +26,10 @@
   }
 }
 
+.site-header {
+  border-bottom-color: $color-primary;
+}
+
 // Sidebar navigation --------- //
 
 .sidebar-nav {

--- a/lib/guides_style_18f/sass/_guides_style_18f_main.scss
+++ b/lib/guides_style_18f/sass/_guides_style_18f_main.scss
@@ -23,6 +23,7 @@ global styles
 */
 
 html, body {
+  background-color: pink;
     height: 100%;
 }
 

--- a/lib/guides_style_18f/sass/guides_style_18f.scss
+++ b/lib/guides_style_18f/sass/guides_style_18f.scss
@@ -1,4 +1,5 @@
-@import "./_guides_style_18f_main";
+// @import "./_guides_style_18f_main";
+// @import "./_guides_style_18f_custom-old";
 @import "./_guides_style_18f_syntax";
-@import "./_guides_style_18f_custom";
 @import "us_web_design_standards";
+@import "./_guides_style_18f_custom";

--- a/lib/guides_style_18f/sass/guides_style_18f.scss
+++ b/lib/guides_style_18f/sass/guides_style_18f.scss
@@ -1,3 +1,4 @@
 @import "./_guides_style_18f_main";
 @import "./_guides_style_18f_syntax";
 @import "./_guides_style_18f_custom";
+@import "us_web_design_standards";

--- a/lib/guides_style_18f/version.rb
+++ b/lib/guides_style_18f/version.rb
@@ -1,5 +1,5 @@
 # @author Mike Bland (michael.bland@gsa.gov)
 
 module GuidesStyle18F
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 end

--- a/lib/guides_style_18f/version.rb
+++ b/lib/guides_style_18f/version.rb
@@ -1,5 +1,5 @@
 # @author Mike Bland (michael.bland@gsa.gov)
 
 module GuidesStyle18F
-  VERSION = '0.1.4'
+  VERSION = '0.1.5'
 end


### PR DESCRIPTION
This is just the first step. The dependency is in the gemspec, the generator and sass modules depend on us_web_design_standards to integrate that gem's generator and sass modules, and the guides_style_18f.scss file imports the us_web_design_standards styles.

However, this initial commit does not update the layouts, includes, and styles to use the us_web_design_standards styles.

@maya and @msecret: Here's how you can work on this branch to integrate the design standards styles while testing with 18F/guides-template. First, clone both repos, making sure to clone 18F/guides-style with this PR's branch:

``` sh
$ git clone git@github.com:18F/guides-style --branch uswds
$ git clone git@github.com:18F/guides-template
$ cd guides-template
```

Then update the `guides_style_18f` line of the guides-template `Gemfile` to:

``` ruby
gem 'guides_style_18f', path: '../guides-style'
```

Then run the following to update the `Gemfile.lock` and run the site locally:

``` sh
$ bundle install
$ ./go serve
```

Now, you'll want to change directories back to `../guides-style`, and update the layouts, includes, and styles in there. You'll find them all under `lib/guides_style_18f` in the `layouts`, `includes`, and `sass` directories, respectively. Do anything and everything you feel you need to do to those files.

Don't hesitate to ping me if you have any questions!
