### PR TITLE
Add repository link to footer

### DIFF
--- a/lib/guides_style_18f/includes/footer.html
+++ b/lib/guides_style_18f/includes/footer.html
@@ -1,9 +1,9 @@
 <footer role="contentinfo">
-  <div class="wrap">
-    <p>This project is maintained by <a href="{{ site.author.url }}">{{ site.author.name }}</a>.</p>
+  <div class="wrap">{% assign repo_url = site.repos[0].url %}
+    <p>This project is maintained by <a href="{{ site.author.url }}">{{ site.author.name }}</a>. The source is available at <a href="{{ repo_url }}">{{ repo_url }}</a>.</p>
 
     <p>Hosted on <a href="https://github.com/18F/pages/">18F Pages</a>.
     The <a href="https://github.com/18F/guides-template/">18F Guides theme</a> is based on <a href="https://github.com/cfpb/docter/">DOCter</a> from <a href="http://cfpb.github.io/">CFPB</a>.</p>
-    <p><a href="{{ site.repos[0].url }}/edit/18f-pages/{{ page.path }}">Edit this page</a> or <a href="{{ site.repos[0].url }}/issues">file an issue</a> on GitHub.</p>
+    <p><a href="{{ repo_url }}/edit/18f-pages/{{ page.path }}">Edit this page</a> or <a href="{{ repo_url }}/issues">file an issue</a> on GitHub.</p>
   </div><!--/.wrap -->
 </footer>


### PR DESCRIPTION
Closes #15.

The footer now appears as:

![footer](https://cloud.githubusercontent.com/assets/301547/11153764/1e4c0c64-8a09-11e5-82d5-58be07cdce4e.png)

cc: @ultrasaurus @gbinal @emileighoutlaw 