### PR TITLE
Removing async attr from script tags in lib/includes/scripts.html

### DIFF
--- a/lib/guides_style_18f/includes/scripts.html
+++ b/lib/guides_style_18f/includes/scripts.html
@@ -1,5 +1,5 @@
-<script async src="https://code.jquery.com/jquery-1.11.2.min.js"></script>
-<script async src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
-<script async src="{% guides_style_18f_asset_root %}/assets/js/accordion.js"></script>{% for script in site.scripts %}
-<script async src="{{ site.baseurl }}/{{ script }}"></script>{% endfor %}{% for script in page.scripts %}
-<script async src="{{ site.baseurl }}/{{ script }}"></script>{% endfor %}
+<script src="https://code.jquery.com/jquery-1.11.2.min.js"></script>
+<script src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+<script src="{% guides_style_18f_asset_root %}/assets/js/accordion.js"></script>{% for script in site.scripts %}
+<script src="{{ site.baseurl }}/{{ script }}"></script>{% endfor %}{% for script in page.scripts %}
+<script src="{{ site.baseurl }}/{{ script }}"></script>{% endfor %}


### PR DESCRIPTION
Fixes #18 

Longer term, I *highly* recommend we move away from CDN and towards hosting jQuery from the repo instead. I think this expands beyond to scope of this issue and have opened another issue for the team to take into consideration.

**Move jQuery from CDN to self hosted in repo**
https://github.com/18F/guides-style/issues/19

Also reference https://github.com/18F/pages/issues/53 where @mbland debugged the original issue.