### PR TITLE
Fix styling of sidebar nav line

### DIFF
--- a/lib/guides_style_18f/sass/_guides_style_18f_main.scss
+++ b/lib/guides_style_18f/sass/_guides_style_18f_main.scss
@@ -203,7 +203,6 @@ Navigation
   list-style: none;
   border-bottom: 1px solid #babbbd;
   font-size: 1.125em;
-  padding-left: 4px;
   overflow: hidden;
 }
 


### PR DESCRIPTION
This fixes the sidebar nav styling so that the blue line aligns with the left edge.

This is what it looks like now:

<img width="289" alt="screen shot 2016-01-04 at 3 21 54 pm" src="https://cloud.githubusercontent.com/assets/5249443/12103464/483616de-b2f7-11e5-9ad5-115ac7e5984a.png">

This is what it looks like before:

<img width="338" alt="screen shot 2016-01-04 at 3 21 38 pm" src="https://cloud.githubusercontent.com/assets/5249443/12103462/462d0078-b2f7-11e5-9788-532f0096d28b.png">

Note: I wasn't able to test this locally so please verify this works as intended @mbland.