### PR TITLE
Update media queries to remove min height

### DIFF
--- a/lib/guides_style_18f/sass/_guides_style_18f_main.scss
+++ b/lib/guides_style_18f/sass/_guides_style_18f_main.scss
@@ -497,7 +497,7 @@ Desktop Styles
 ==================================
 */
 
-@media screen and (min-width: 45em) and (min-height: 32.5em) {
+@media screen and (min-width: 45em) {
 
     /*
     Typography
@@ -582,7 +582,7 @@ Desktop Styles
 
 }
 
-@media screen and (max-width: 54.375em) and (min-height: 32.5em) {
+@media screen and (max-width: 54.375em) {
 
     /* keep the repo list containers the same height, but account for the need for more height */
 


### PR DESCRIPTION
This removes min-height from media queries to prevent the mobile collapsing when the vertical height is smaller.

Note: @mbland I wasn't able to test this locally so please test to make sure it works as intended.