### PR TITLE
Build nav based on permalinks, not `parent` titles

### DIFF
--- a/test/_pages/add-a-new-page/make-a-child-page.md
+++ b/test/_pages/add-a-new-page/make-a-child-page.md
@@ -1,4 +1,3 @@
 ---
 title: Make a child page
-parent: Add a new page
 ---

--- a/test/_pages/update-the-config-file/understanding-baseurl.md
+++ b/test/_pages/update-the-config-file/understanding-baseurl.md
@@ -1,4 +1,3 @@
 ---
 title: Understanding the `baseurl:` property
-parent: Update the config file
 ---


### PR DESCRIPTION
After #26, I realized that there's no need to require the `parent:` front matter, as it's possible to compute parent-child relationships using `permalink:` values. This completely replaces the earlier implementation that was based on matching `parent:` with the `text:` of other `navigation:` items, but passes all of the earlier tests (with one tweak to `test_should_raise_if_parent_page_does_not_exist`). Added the new `test_do_not_remove_external_page_entries`, moved another test, and slightly refactored another.

cc: @ccostino @ertzeid 