### PR TITLE
Remove new images.png, recursively remove child nav items

### DIFF
--- a/lib/guides_style_18f/navigation.rb
+++ b/lib/guides_style_18f/navigation.rb
@@ -5,6 +5,8 @@ require 'safe_yaml'
 
 module GuidesStyle18F
   module FrontMatter
+    EXTNAMES = %w(.md .html)
+
     def self.load(basedir)
       # init_file_to_front_matter_map is initializing the map with a nil value
       # for every file that _should_ contain front matter as far as the
@@ -87,7 +89,8 @@ module GuidesStyle18F
       Dir.chdir(basedir) do
         pages_dir = Dir.exist?('_pages') ? '_pages' : 'pages'
         Dir[File.join(pages_dir, '**', '*')].each do |file_name|
-          next unless File.file?(file_name)
+          extname = File.extname(file_name)
+          next unless File.file?(file_name) && EXTNAMES.include?(extname)
           file_to_front_matter[file_name] = nil
         end
       end

--- a/lib/guides_style_18f/repository.rb
+++ b/lib/guides_style_18f/repository.rb
@@ -9,6 +9,7 @@ module GuidesStyle18F
     _pages/add-a-new-page.md
     _pages/add-images.md
     _pages/github-setup.md
+    _pages/images.png
     _pages/post-your-guide.md
     _pages/update-the-config-file/understanding-baseurl.md
     _pages/update-the-config-file.md
@@ -19,7 +20,6 @@ module GuidesStyle18F
     images/gh-default-branch.png
     images/gh-settings-button.png
     images/gh-webhook.png
-    images/images.png
   )
 
   def self.clear_template_files_and_create_new_repository(

--- a/test/navigation_test.rb
+++ b/test/navigation_test.rb
@@ -393,6 +393,14 @@ EXPECTED_ERRORS
       assert_equal EXPECTED_ERRORS, errors + "\n"
     end
 
+    def test_ignore_static_files
+      write_config NAV_YAML
+      write_page('image.png', '')
+      errors = GuidesStyle18F::FrontMatter.validate_with_message_upon_error(
+        GuidesStyle18F::FrontMatter.load(testdir))
+      assert_nil(errors)
+    end
+
     def capture_stderr
       orig_stderr = $stderr
       $stderr = StringIO.new


### PR DESCRIPTION
Addresses item noted in 18F/guides-template#68.

Note that the bulk of the changes to `navigation.rb` are indentations after creating the `NavigationData` module. The _real_ new code is `remove_stale_children`, called from `remove_stale_nav_entries`.

cc: @ccostino @ertzeid @emileighoutlaw 
