### PR TITLE
Support short nav titles, expanded nav bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ back_link:
 
 # If you use Analytics, add your code here:
 google_analytics_ua: UA-????????-??
+
+# If you want all of the navigation bar entries expanded by default, add this
+# property and it to true:
+expand_nav: true
 ```
 
 ### Additional scripts and styles
@@ -65,6 +69,18 @@ google_analytics_ua: UA-????????-??
 If you'd like to add additional scripts or styles to every page on the site,
 you can add `styles:` and `scripts:` lists to `_config.yml`. To add them to a
 particular page, add these lists to the page's front matter.
+
+### Alternate navigation bar titles
+
+If you want a page to have a different title in the navigation bar than that
+of the page itself, add a `navtitle:` property to the page's front matter:
+
+```md
+---
+title: Since brevity is the soul of wit, I'll be brief.
+navtitle: Polonius's advice
+---
+```
 
 ### Development
 

--- a/lib/guides_style_18f/includes/sidebar-children.html
+++ b/lib/guides_style_18f/includes/sidebar-children.html
@@ -5,11 +5,11 @@
         aria-controls="nav-collapsible-{{ forloop.index }}">+</button>
 <ul class="nav-children" id="nav-collapsible-{{ forloop.index }}"
     aria-hidden="{% if expand_nav == 'true' %}false{% else %}true{% endif %}">
-  {% for child in parent.children %}
+  {% for child in parent.children %}{% assign navtitle = page.title %}{% if page.navtitle %}{% assign navtitle = page.navtitle %}{% endif %}
   {% capture child_url %}{{ parent_url }}{{ child.url }}{% endcapture %}
-    <li class="{% if page.title == child.text %}sidebar-nav-active{% endif %}">
+    <li class="{% if navtitle == child.text %}sidebar-nav-active{% endif %}">
       <a href="{% if child.internal == true %}{{ site.baseurl }}{{ child_url }}{% else %}{{ child.url }}{% endif %}"
-        title="{% if page.title == child.text %}Current Page{% else %}{{ child.text }}{% endif %}">{{ child.text }}</a>
+        title="{% if navtitle == child.text %}Current Page{% else %}{{ child.text }}{% endif %}">{{ child.text }}</a>
       {% assign parent = child %}{% assign parent_url = child_url %}
       {% guides_style_18f_include sidebar-children.html %}
       {% capture parent_url %}{% guides_style_18f_pop_last_url_component parent_url %}{% endcapture %}

--- a/lib/guides_style_18f/includes/sidebar-children.html
+++ b/lib/guides_style_18f/includes/sidebar-children.html
@@ -5,11 +5,11 @@
         aria-controls="nav-collapsible-{{ forloop.index }}">+</button>
 <ul class="nav-children" id="nav-collapsible-{{ forloop.index }}"
     aria-hidden="{% if expand_nav == 'true' %}false{% else %}true{% endif %}">
-  {% for child in parent.children %}{% assign navtitle = page.title %}{% if page.navtitle %}{% assign navtitle = page.navtitle %}{% endif %}
+  {% for child in parent.children %}
   {% capture child_url %}{{ parent_url }}{{ child.url }}{% endcapture %}
-    <li class="{% if navtitle == child.text %}sidebar-nav-active{% endif %}">
+    <li class="{% if page.url == child_url %}sidebar-nav-active{% endif %}">
       <a href="{% if child.internal == true %}{{ site.baseurl }}{{ child_url }}{% else %}{{ child.url }}{% endif %}"
-        title="{% if navtitle == child.text %}Current Page{% else %}{{ child.text }}{% endif %}">{{ child.text }}</a>
+        title="{% if page.url == child_url %}Current Page{% else %}{{ child.text }}{% endif %}">{{ child.text }}</a>
       {% assign parent = child %}{% assign parent_url = child_url %}
       {% guides_style_18f_include sidebar-children.html %}
       {% capture parent_url %}{% guides_style_18f_pop_last_url_component parent_url %}{% endcapture %}

--- a/lib/guides_style_18f/includes/sidebar.html
+++ b/lib/guides_style_18f/includes/sidebar.html
@@ -1,13 +1,12 @@
 <aside>
   <p class="intro">{{ site.subtitle }}</p>
   <nav class="sidebar-nav" role="navigation">
-    <ul>{% for link in site.navigation %}{% assign navtitle = page.title %}{% if page.navtitle %}{% assign navtitle = page.navtitle %}{% endif %}
-        <li class="group {% if navtitle == link.text %}sidebar-nav-active{% endif %}">
+    <ul>{% for link in site.navigation %}{% capture parent_url %}/{{ link.url }}{% endcapture %}
+        <li class="group {% if page.url == parent_url %}sidebar-nav-active{% endif %}">
           <a href="{% if link.internal == true %}{{ site.baseurl }}/{% endif %}{{ link.url }}"  
-            title="{% if navtitle == link.text %}Current Page
+            title="{% if page.url == parent_url %}Current Page
                   {% else %}{{ link.text }}{% endif %}">{{ link.text }}</a>
           {% assign parent = link %}
-          {% capture parent_url %}/{{ link.url }}{% endcapture %}
           {% guides_style_18f_include sidebar-children.html %}
         </li>{% endfor %}
     </ul>

--- a/lib/guides_style_18f/includes/sidebar.html
+++ b/lib/guides_style_18f/includes/sidebar.html
@@ -1,10 +1,10 @@
 <aside>
   <p class="intro">{{ site.subtitle }}</p>
   <nav class="sidebar-nav" role="navigation">
-    <ul>{% for link in site.navigation %}
-        <li class="group {% if page.title == link.text %}sidebar-nav-active{% endif %}">
+    <ul>{% for link in site.navigation %}{% assign navtitle = page.title %}{% if page.navtitle %}{% assign navtitle = page.navtitle %}{% endif %}
+        <li class="group {% if navtitle == link.text %}sidebar-nav-active{% endif %}">
           <a href="{% if link.internal == true %}{{ site.baseurl }}/{% endif %}{{ link.url }}"  
-            title="{% if page.title == link.text %}Current Page
+            title="{% if navtitle == link.text %}Current Page
                   {% else %}{{ link.text }}{% endif %}">{{ link.text }}</a>
           {% assign parent = link %}
           {% capture parent_url %}/{{ link.url }}{% endcapture %}

--- a/lib/guides_style_18f/navigation.rb
+++ b/lib/guides_style_18f/navigation.rb
@@ -155,7 +155,7 @@ module GuidesStyle18F
     def self.page_nav(front_matter)
       url_components = front_matter['permalink'].split('/')[1..-1]
       result = {
-        'text' => front_matter['title'],
+        'text' => front_matter['navtitle'] || front_matter['title'],
         'url' => "#{url_components.nil? ? '' : url_components.last}/",
         'internal' => true,
       }

--- a/lib/guides_style_18f/tags.rb
+++ b/lib/guides_style_18f/tags.rb
@@ -13,6 +13,7 @@ module GuidesStyle18F
     end
 
     def render(context)
+      return true if context['site']['expand_nav']
       scope = context.scopes.detect { |s| s.member?(reference) }
       parent_url = scope[reference]
       page_url = context['page']['url']

--- a/test/navigation_test.rb
+++ b/test/navigation_test.rb
@@ -401,6 +401,24 @@ EXPECTED_ERRORS
       assert_nil(errors)
     end
 
+    WITH_NAVTITLE = <<WITH_NAVTITLE
+---
+title: Some egregiously, pretentiously, criminally long title
+navtitle: Hello!
+---
+WITH_NAVTITLE
+
+    def test_use_navtitle_if_present
+      write_config NAV_YAML
+      write_page('navtitle.md', WITH_NAVTITLE)
+      GuidesStyle18F.update_navigation_configuration testdir
+      expected = [{
+        'text' => 'Hello!', 'url' => 'navtitle/', 'internal' => true
+      }]
+      result = SafeYAML.load(read_config, safe: true)
+      assert_equal(expected, result['navigation'])
+    end
+
     def capture_stderr
       orig_stderr = $stderr
       $stderr = StringIO.new

--- a/test/tags_test.rb
+++ b/test/tags_test.rb
@@ -12,6 +12,7 @@ module GuidesStyle18F
       @should_expand_nav = tag_class.parse(
         ShouldExpandNavTag::NAME, ' nav_parent_url ', nil, nil)
       @context = ::Liquid::Context.new
+      context['site'] = {}
       context.scopes.push('nav_parent_url' => '/foo/')
     end
 
@@ -28,6 +29,12 @@ module GuidesStyle18F
     def test_is_not_a_child_or_grandchild
       context['page'] = { 'url' => '/bar/' }
       refute should_expand_nav.render(context)
+    end
+
+    def test_expand_nav_site_variable_is_set
+      context['page'] = { 'url' => '/bar/' }
+      context['site']['expand_nav'] = true
+      assert should_expand_nav.render(context)
     end
 
     def test_is_the_page_itself


### PR DESCRIPTION
Closes #31.

#30 should go in before this one.

This does two things:

- Supports `navtitle:` front matter that allows for alternate text in the nav bar.
- Adds the `expand_nav:` site variable (in `_config.yml`) that, when set to `true`, will expand all of the nav bar entries.

cc: @afeld @leahbannon @ccostino @ertzeid 