### PR TITLE
`expand_nav:` per `navigation:` item

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,37 @@ navtitle: Polonius's advice
 ---
 ```
 
+### Selectively expanding navigation bar items
+
+If you wish to expand or contract specific navigation bar items, add the
+`expand_nav:` property to those items in the `navigation:` list in
+`_config.yml`. For example, the `Update the config file` entry will expand
+since the default `expand_nav` property is `true`, but `Add a new page` will
+remain collapsed:
+
+```yaml
+expand_nav: true
+
+navigation:
+- text: Introduction
+  internal: true
+- text: Add a new page
+  url: add-a-new-page/
+  internal: true
+  expand_nav: false
+  children:
+  - text: Make a child page
+    url: make-a-child-page/
+    internal: true
+- text: Update the config file
+  url: update-the-config-file/
+  internal: true
+  children:
+  - text: Understanding the `baseurl:` property
+    url: understanding-baseurl/
+    internal: true
+```
+
 ### Development
 
 First, choose a Jekyll site you'd like to use to view the impact of your

--- a/lib/guides_style_18f/includes/sidebar-children.html
+++ b/lib/guides_style_18f/includes/sidebar-children.html
@@ -1,5 +1,5 @@
 {% if parent.children %}
-{% capture expand_nav %}{% guides_style_18f_should_expand_nav parent_url %}{% endcapture %}
+{% capture expand_nav %}{% guides_style_18f_should_expand_nav parent, parent_url %}{% endcapture %}
 <button class="expand-subnav"
         aria-expanded="{{ expand_nav }}"
         aria-controls="nav-collapsible-{{ forloop.index }}">+</button>

--- a/lib/guides_style_18f/tags.rb
+++ b/lib/guides_style_18f/tags.rb
@@ -6,18 +6,28 @@ module GuidesStyle18F
     NAME = 'guides_style_18f_should_expand_nav'
     ::Liquid::Template.register_tag(NAME, self)
 
-    attr_reader :reference
+    attr_reader :parent_reference, :url_reference
 
     def initialize(_tag_name, markup, _)
-      @reference = markup.strip
+      references = markup.split(',').map(&:strip)
+      @parent_reference = references.shift
+      @url_reference = references.shift
     end
 
     def render(context)
-      return true if context['site']['expand_nav']
-      scope = context.scopes.detect { |s| s.member?(reference) }
-      parent_url = scope[reference]
+      scope = context.scopes.detect { |s| s.member?(url_reference) }
+      parent_url = scope[url_reference]
       page_url = context['page']['url']
-      page_url != parent_url && page_url.start_with?(parent_url)
+      (page_url != parent_url && page_url.start_with?(parent_url)) || (
+        expand_nav_default(scope, context))
+    end
+
+    private
+
+    def expand_nav_default(scope, context)
+      default = scope[parent_reference]['expand_nav']
+      default = context['site']['expand_nav'] if default.nil?
+      default.nil? ? false : default
     end
   end
 


### PR DESCRIPTION
Closes 18F/pages#54.

This allows individual navigation bar items to be expanded or contracted, overriding the default provided by the top-level `expand_nav:` property.

cc: @afeld @brittag 