### PR TITLE
Don't stretch small images beyond their width

### DIFF
--- a/lib/guides_style_18f/sass/_guides_style_18f_main.scss
+++ b/lib/guides_style_18f/sass/_guides_style_18f_main.scss
@@ -328,9 +328,7 @@ header {
 }
 
 .main-content img {
-  width: auto;
   max-width: 100%;
-  height: auto;
 }
 
 /*

--- a/lib/guides_style_18f/sass/_guides_style_18f_main.scss
+++ b/lib/guides_style_18f/sass/_guides_style_18f_main.scss
@@ -328,8 +328,9 @@ header {
 }
 
 .main-content img {
-    width: 100%;
-
+  width: auto;
+  max-width: 100%;
+  height: auto;
 }
 
 /*


### PR DESCRIPTION
Addresses an issue from #22. Just noticed that the existing style forces small images to stretch; see the example below from https://pages.18f.gov/guides-template/post-your-guide/#set-default-branch. This change seems to address the issue, yet larger images remain responsive.

cc: @juliaelman @maya 

---

## Before, desktop view

![before](https://cloud.githubusercontent.com/assets/301547/12374054/41fa6764-bc5e-11e5-9f43-12eff58f3e67.png)

---

## After, desktop view

![after](https://cloud.githubusercontent.com/assets/301547/12374060/5c75645e-bc5e-11e5-8119-48881f36ef53.png)

---

## After, responsive view
![after-responsive](https://cloud.githubusercontent.com/assets/301547/12374070/9d0bd070-bc5e-11e5-8cea-2b3a8f1c016c.png)