### PR TITLE
Breadcrumb implementation

### DIFF
--- a/lib/guides_style_18f.rb
+++ b/lib/guides_style_18f.rb
@@ -1,6 +1,7 @@
 # @author Mike Bland (michael.bland@gsa.gov)
 
 require 'guides_style_18f/assets'
+require 'guides_style_18f/breadcrumbs'
 require 'guides_style_18f/generator'
 require 'guides_style_18f/includes'
 require 'guides_style_18f/layouts'

--- a/lib/guides_style_18f/breadcrumbs.rb
+++ b/lib/guides_style_18f/breadcrumbs.rb
@@ -1,0 +1,21 @@
+require 'jekyll'
+require 'safe_yaml'
+
+module GuidesStyle18F
+  class Breadcrumbs
+    def self.create(site)
+      (site.config['navigation'] || []).flat_map do |nav|
+        Breadcrumbs.generate_breadcrumbs(nav, '/', [])
+      end.to_h
+    end
+
+    def self.generate_breadcrumbs(nav, parent_url, parents)
+      url = parent_url + (nav['url'] || '')
+      crumbs = parents + [{ 'url' => url, 'text' => nav['text'] }]
+      child_crumbs = (nav['children'] || []).flat_map do |child|
+        generate_breadcrumbs(child, url, crumbs)
+      end
+      [[url, crumbs]] + child_crumbs
+    end
+  end
+end

--- a/lib/guides_style_18f/generator.rb
+++ b/lib/guides_style_18f/generator.rb
@@ -11,6 +11,20 @@ module GuidesStyle18F
       site.collections['pages'].docs.each do |page|
         page.data['breadcrumbs'] = breadcrumbs[page.url]
       end
+      flatten_url_namespace(site) if site.config['flat_namespace']
+    end
+
+    def flatten_url_namespace(site)
+      site.collections['pages'].docs.each do |page|
+        page.data['permalink'] = flat_url(page.url)
+        (page.data['breadcrumbs'] || []).each do |crumb|
+        crumb['url'] = flat_url(crumb['url'])
+        end
+      end
+    end
+
+    def flat_url(url)
+      File.join('', File.basename(url), '')
     end
   end
 end

--- a/lib/guides_style_18f/generator.rb
+++ b/lib/guides_style_18f/generator.rb
@@ -5,8 +5,12 @@ require 'jekyll'
 module GuidesStyle18F
   class Generator < ::Jekyll::Generator
     def generate(site)
+      breadcrumbs = Breadcrumbs.create(site)
       Layouts.register site
       Assets.copy_to_site site
+      site.collections['pages'].docs.each do |page|
+        page.data['breadcrumbs'] = breadcrumbs[page.url]
+      end
     end
   end
 end

--- a/lib/guides_style_18f/includes/breadcrumbs.html
+++ b/lib/guides_style_18f/includes/breadcrumbs.html
@@ -1,0 +1,8 @@
+<nav class="nav-main">
+  <div class="wrapper">
+    <ol class="breadcrumbs">
+    {% for breadcrumb in page.breadcrumbs %}<li>{% if forloop.last %}{{ breadcrumb.text }}{% else %}<a href="{{ site.baseurl}}{{ breadcrumb.url }}">{{ breadcrumb.text }}</a>{% endif %}</li>
+    {% endfor %}
+    </div>
+  </div>
+</nav>

--- a/lib/guides_style_18f/navigation.rb
+++ b/lib/guides_style_18f/navigation.rb
@@ -99,7 +99,9 @@ module GuidesStyle18F
 
     def self.missing_property_errors(data)
       properties = %w(title permalink)
-      properties.map { |p| "no `#{p}:` property" unless data[p] }.compact
+      properties.map do |p|
+        "no `#{p}:` property" if data[p].nil?
+      end.compact
     end
 
     def self.permalink_errors(data)

--- a/lib/guides_style_18f/navigation.rb
+++ b/lib/guides_style_18f/navigation.rb
@@ -99,9 +99,7 @@ module GuidesStyle18F
 
     def self.missing_property_errors(data)
       properties = %w(title permalink)
-      properties.map do |p|
-        "no `#{p}:` property" if data[p].nil?
-      end.compact
+      properties.map { |p| "no `#{p}:` property" if data[p].nil? }.compact
     end
 
     def self.permalink_errors(data)

--- a/test/breadcrumbs_test.rb
+++ b/test/breadcrumbs_test.rb
@@ -1,0 +1,92 @@
+require_relative '../lib/guides_style_18f/breadcrumbs'
+
+require 'minitest/autorun'
+
+module GuidesStyle18F
+  class DummySite
+    attr_accessor :config
+
+    def initialize
+      @config = {}
+    end
+  end
+
+  class BreadcrumbsTest < ::Minitest::Test
+    attr_accessor :site
+
+    def setup
+      @site = DummySite.new
+    end
+
+    def test_empty_data
+      assert_empty(Breadcrumbs.create(site))
+    end
+
+    def test_single_nav_item_for_home_page_without_url_member
+      site.config['navigation'] = [{ 'text' => 'Introduction' }]
+      expected = { '/' => [{ 'url' => '/', 'text' => 'Introduction' }] }
+      assert_equal(expected, Breadcrumbs.create(site))
+    end
+
+    def test_multiple_nav_items
+      site.config['navigation'] = [
+        { 'text' => 'Introduction' },
+        { 'url' => 'foo/', 'text' => 'Foo info' },
+      ]
+      expected = {
+        '/' => [{ 'url' => '/', 'text' => 'Introduction' }],
+        '/foo/' => [{ 'url' => '/foo/', 'text' => 'Foo info' }],
+      }
+      assert_equal(expected, Breadcrumbs.create(site))
+    end
+
+    # rubocop:disable MethodLength
+    def test_nav_items_with_children
+      site.config['navigation'] = [
+        { 'text' => 'Introduction' },
+        { 'url' => 'foo/',
+          'text' => 'Foo info',
+          'children' => [
+            { 'url' => 'bar/', 'text' => 'Bar info' },
+            { 'url' => 'baz/', 'text' => 'Baz info' },
+          ],
+        },
+        { 'url' => 'quux/',
+          'text' => 'Quux info',
+          'children' => [
+            { 'url' => 'xyzzy/',
+              'text' => 'Xyzzy info',
+              'children' => [
+                { 'url' => 'plugh/', 'text' => 'Plugh info' },
+              ],
+            },
+          ],
+        },
+      ]
+      expected = {
+        '/' => [{ 'url' => '/', 'text' => 'Introduction' }],
+        '/foo/' => [{ 'url' => '/foo/', 'text' => 'Foo info' }],
+        '/foo/bar/' => [
+          { 'url' => '/foo/', 'text' => 'Foo info' },
+          { 'url' => '/foo/bar/', 'text' => 'Bar info' },
+        ],
+        '/foo/baz/' => [
+          { 'url' => '/foo/', 'text' => 'Foo info' },
+          { 'url' => '/foo/baz/', 'text' => 'Baz info' },
+        ],
+        '/quux/' => [{ 'url' => '/quux/', 'text' => 'Quux info' }],
+        '/quux/xyzzy/' => [
+          { 'url' => '/quux/', 'text' => 'Quux info' },
+          { 'url' => '/quux/xyzzy/', 'text' => 'Xyzzy info' },
+        ],
+        '/quux/xyzzy/plugh/' => [
+          { 'url' => '/quux/', 'text' => 'Quux info' },
+          { 'url' => '/quux/xyzzy/', 'text' => 'Xyzzy info' },
+          { 'url' => '/quux/xyzzy/plugh/', 'text' => 'Plugh info' },
+        ],
+      }
+      assert_equal(expected, Breadcrumbs.create(site))
+    end
+    # rubocop:enable MethodLength
+  end
+end

--- a/test/navigation_test.rb
+++ b/test/navigation_test.rb
@@ -342,12 +342,6 @@ module GuidesStyle18F
       assert_result_matches_expected_config(NAV_DATA)
     end
 
-    MISSING_TITLE = <<MISSING_TITLE
----
-other_property: other value
----
-MISSING_TITLE
-
     NO_LEADING_SLASH = <<NO_LEADING_SLASH
 ---
 title: No leading slash
@@ -364,7 +358,6 @@ NO_TRAILING_SLASH
 
     FILES_WITH_ERRORS = {
       'missing-front-matter.md' => 'no front matter brosef',
-      'missing-title.md' => MISSING_TITLE,
       'no-leading-slash.md' => NO_LEADING_SLASH,
       'no-trailing-slash.md' => NO_TRAILING_SLASH,
     }
@@ -373,8 +366,6 @@ NO_TRAILING_SLASH
 The following files have errors in their front matter:
   _pages/missing-front-matter.md:
     no front matter defined
-  _pages/missing-title.md:
-    no `title:` property
   _pages/no-leading-slash.md:
     `permalink:` does not begin with '/'
   _pages/no-trailing-slash.md:


### PR DESCRIPTION
Uses the `navigation:` data (generated by `./go update_nav` and stored in `_config.yml`) to produce a mapping from page URL to a list of breadcrumb objects. `Generator.generate` attaches this data to each page, and the `includes/breadcrumbs.html` template renders it as an unordered list.

The breadcrumbs are not yet included and styled in the standard layout, but can be included using the following Liquid directive:

```
  {% guides_style_18f_include breadcrumbs.html %}
```

Also includes a test fix for newer versions of Jekyll, which will now provide a default `title:` property for a page based on its URL slug if a `title:` isn't specified in the page's front matter.

cc: @andrewmaier @ccostino @ertzeid @mtorres253 

Also cc: @catherinedevlin and @DavidEBest, in case you feel like picking up some Pages-related code reviews. :smiley: