### PR TITLE
Implement and test flat URL namespacing

### DIFF
--- a/lib/guides_style_18f/breadcrumbs.rb
+++ b/lib/guides_style_18f/breadcrumbs.rb
@@ -3,7 +3,12 @@ require 'safe_yaml'
 
 module GuidesStyle18F
   class Breadcrumbs
-    def self.create(site)
+    def self.generate(site, docs)
+      breadcrumbs = create_breadcrumbs(site)
+      docs.each { |page| page.data['breadcrumbs'] = breadcrumbs[page.url] }
+    end
+
+    def self.create_breadcrumbs(site)
       (site.config['navigation'] || []).flat_map do |nav|
         Breadcrumbs.generate_breadcrumbs(nav, '/', [])
       end.to_h

--- a/lib/guides_style_18f/generator.rb
+++ b/lib/guides_style_18f/generator.rb
@@ -1,24 +1,30 @@
 # @author Mike Bland (michael.bland@gsa.gov)
 
+require_relative './assets'
+require_relative './breadcrumbs'
+require_relative './layouts'
+
 require 'jekyll'
 
 module GuidesStyle18F
   class Generator < ::Jekyll::Generator
     def generate(site)
-      breadcrumbs = Breadcrumbs.create(site)
       Layouts.register site
       Assets.copy_to_site site
-      site.collections['pages'].docs.each do |page|
-        page.data['breadcrumbs'] = breadcrumbs[page.url]
-      end
-      flatten_url_namespace(site) if site.config['flat_namespace']
+      breadcrumbs = Breadcrumbs.create(site)
+      pages = site.collections['pages']
+      docs = pages.nil? ? [] : pages.docs
+      docs.each { |page| page.data['breadcrumbs'] = breadcrumbs[page.url] }
+      flatten_url_namespace(docs) if site.config['flat_namespace']
     end
 
-    def flatten_url_namespace(site)
-      site.collections['pages'].docs.each do |page|
+    private
+
+    def flatten_url_namespace(docs)
+      docs.each do |page|
         page.data['permalink'] = flat_url(page.url)
         (page.data['breadcrumbs'] || []).each do |crumb|
-        crumb['url'] = flat_url(crumb['url'])
+          crumb['url'] = flat_url(crumb['url'])
         end
       end
     end

--- a/lib/guides_style_18f/generator.rb
+++ b/lib/guides_style_18f/generator.rb
@@ -11,6 +11,20 @@ module GuidesStyle18F
       site.collections['pages'].docs.each do |page|
         page.data['breadcrumbs'] = breadcrumbs[page.url]
       end
+      flatten_url_namespace(site) if site.config['flat_namespace']
+    end
+
+    def flatten_url_namespace(site)
+      site.collections['pages'].docs.each do |page|
+        page.data['permalink'] = flat_url(page.url)
+        (page.data['breadcrumbs'] || []).each do |crumb|
+        crumb['url'] = flat_url(crumb['url'])
+        end
+      end
+    end
+
+    def flat_url(url)
+      File.join('', File.basename(url), '')
     end
   end
 end

--- a/lib/guides_style_18f/generator.rb
+++ b/lib/guides_style_18f/generator.rb
@@ -3,6 +3,7 @@
 require_relative './assets'
 require_relative './breadcrumbs'
 require_relative './layouts'
+require_relative './namespace_flattener'
 
 require 'jekyll'
 
@@ -11,42 +12,11 @@ module GuidesStyle18F
     def generate(site)
       Layouts.register site
       Assets.copy_to_site site
-      breadcrumbs = Breadcrumbs.create(site)
       pages = site.collections['pages']
-      docs = pages.nil? ? [] : pages.docs
+      docs = (pages.nil? ? [] : pages.docs) + site.pages
+      breadcrumbs = Breadcrumbs.create(site)
       docs.each { |page| page.data['breadcrumbs'] = breadcrumbs[page.url] }
-      flatten_url_namespace(docs) if site.config['flat_namespace']
-    end
-
-    private
-
-    def flatten_url_namespace(docs)
-      flat_to_orig = {}
-      docs.each do |page|
-        flattened_url = flat_url(page.url)
-        (flat_to_orig[flattened_url] ||= []) << page.url
-        page.data['permalink'] = flattened_url
-        (page.data['breadcrumbs'] || []).each do |crumb|
-          crumb['url'] = flat_url(crumb['url'])
-        end
-      end
-      check_for_collisions(flat_to_orig)
-    end
-
-    def flat_url(url)
-      url == '/' ? url : "/#{url.split('/')[1..-1].last}/"
-    end
-
-    def check_for_collisions(flat_to_orig)
-      collisions = flat_to_orig.map do |flattened, orig|
-        [flattened, orig] if orig.size != 1
-      end.compact
-
-      return if collisions.empty?
-
-      messages = collisions.map { |flat, orig| "#{flat}: #{orig.join(', ')}" }
-      fail(StandardError, "collisions in flattened namespace between\n  " +
-        messages.join("\n  "))
+      NamespaceFlattener.flatten_url_namespace(site, docs)
     end
   end
 end

--- a/lib/guides_style_18f/generator.rb
+++ b/lib/guides_style_18f/generator.rb
@@ -34,7 +34,7 @@ module GuidesStyle18F
     end
 
     def flat_url(url)
-      File.join('', File.basename(url), '')
+      url == '/' ? url : "/#{url.split('/')[1..-1].last}/"
     end
 
     def check_for_collisions(flat_to_orig)

--- a/lib/guides_style_18f/generator.rb
+++ b/lib/guides_style_18f/generator.rb
@@ -10,12 +10,11 @@ require 'jekyll'
 module GuidesStyle18F
   class Generator < ::Jekyll::Generator
     def generate(site)
-      Layouts.register site
-      Assets.copy_to_site site
+      Layouts.register(site)
+      Assets.copy_to_site(site)
       pages = site.collections['pages']
       docs = (pages.nil? ? [] : pages.docs) + site.pages
-      breadcrumbs = Breadcrumbs.create(site)
-      docs.each { |page| page.data['breadcrumbs'] = breadcrumbs[page.url] }
+      Breadcrumbs.generate(site, docs)
       NamespaceFlattener.flatten_url_namespace(site, docs)
     end
   end

--- a/lib/guides_style_18f/namespace_flattener.rb
+++ b/lib/guides_style_18f/namespace_flattener.rb
@@ -6,15 +6,17 @@ module GuidesStyle18F
 
     def self.flatten_urls(docs)
       flat_to_orig = {}
-      docs.each do |page|
-        flattened_url = flat_url(page.url)
-        (flat_to_orig[flattened_url] ||= []) << page.url
-        page.data['permalink'] = flattened_url
-        (page.data['breadcrumbs'] || []).each do |crumb|
-          crumb['url'] = flat_url(crumb['url'])
-        end
-      end
+      docs.each { |page| flatten_page_urls(page, flat_to_orig) }
       check_for_collisions(flat_to_orig)
+    end
+
+    def self.flatten_page_urls(page, flat_to_orig)
+      flattened_url = flat_url(page.url)
+      (flat_to_orig[flattened_url] ||= []) << page.url
+      page.data['permalink'] = flattened_url
+      (page.data['breadcrumbs'] || []).each do |crumb|
+        crumb['url'] = flat_url(crumb['url'])
+      end
     end
 
     def self.flat_url(url)

--- a/lib/guides_style_18f/namespace_flattener.rb
+++ b/lib/guides_style_18f/namespace_flattener.rb
@@ -1,0 +1,36 @@
+module GuidesStyle18F
+  class NamespaceFlattener
+    def self.flatten_url_namespace(site, docs)
+      flatten_urls(docs) if site.config['flat_namespace']
+    end
+
+    def self.flatten_urls(docs)
+      flat_to_orig = {}
+      docs.each do |page|
+        flattened_url = flat_url(page.url)
+        (flat_to_orig[flattened_url] ||= []) << page.url
+        page.data['permalink'] = flattened_url
+        (page.data['breadcrumbs'] || []).each do |crumb|
+          crumb['url'] = flat_url(crumb['url'])
+        end
+      end
+      check_for_collisions(flat_to_orig)
+    end
+
+    def self.flat_url(url)
+      url == '/' ? url : "/#{url.split('/')[1..-1].last}/"
+    end
+
+    def self.check_for_collisions(flat_to_orig)
+      collisions = flat_to_orig.map do |flattened, orig|
+        [flattened, orig] if orig.size != 1
+      end.compact
+
+      return if collisions.empty?
+
+      messages = collisions.map { |flat, orig| "#{flat}: #{orig.join(', ')}" }
+      fail(StandardError, "collisions in flattened namespace between\n  " +
+        messages.join("\n  "))
+    end
+  end
+end

--- a/test/breadcrumbs_test.rb
+++ b/test/breadcrumbs_test.rb
@@ -19,13 +19,13 @@ module GuidesStyle18F
     end
 
     def test_empty_data
-      assert_empty(Breadcrumbs.create(site))
+      assert_empty(Breadcrumbs.create_breadcrumbs(site))
     end
 
     def test_single_nav_item_for_home_page_without_url_member
       site.config['navigation'] = [{ 'text' => 'Introduction' }]
       expected = { '/' => [{ 'url' => '/', 'text' => 'Introduction' }] }
-      assert_equal(expected, Breadcrumbs.create(site))
+      assert_equal(expected, Breadcrumbs.create_breadcrumbs(site))
     end
 
     def test_multiple_nav_items
@@ -37,7 +37,7 @@ module GuidesStyle18F
         '/' => [{ 'url' => '/', 'text' => 'Introduction' }],
         '/foo/' => [{ 'url' => '/foo/', 'text' => 'Foo info' }],
       }
-      assert_equal(expected, Breadcrumbs.create(site))
+      assert_equal(expected, Breadcrumbs.create_breadcrumbs(site))
     end
 
     # rubocop:disable MethodLength
@@ -85,7 +85,7 @@ module GuidesStyle18F
           { 'url' => '/quux/xyzzy/plugh/', 'text' => 'Plugh info' },
         ],
       }
-      assert_equal(expected, Breadcrumbs.create(site))
+      assert_equal(expected, Breadcrumbs.create_breadcrumbs(site))
     end
     # rubocop:enable MethodLength
   end

--- a/test/dummy_collection.rb
+++ b/test/dummy_collection.rb
@@ -1,0 +1,9 @@
+module GuidesStyle18F
+  class DummyCollection
+    attr_accessor :docs
+
+    def initialize(docs)
+      @docs = docs
+    end
+  end
+end

--- a/test/dummy_page.rb
+++ b/test/dummy_page.rb
@@ -1,0 +1,15 @@
+module GuidesStyle18F
+  class DummyPage < ::Jekyll::Page
+    attr_accessor :data
+
+    def initialize(site, permalink)
+      @site = site
+      @data = {}
+      data['permalink'] = permalink
+    end
+
+    def html?
+      true
+    end
+  end
+end

--- a/test/dummy_site.rb
+++ b/test/dummy_site.rb
@@ -1,0 +1,22 @@
+module GuidesStyle18F
+  class DummySite
+    attr_accessor :config, :layouts, :static_files, :collections
+    attr_accessor :permalink_style
+
+    def initialize
+      @config = {}
+      @layouts = {}
+      @static_files = []
+      @collections = {}
+      @permalink_style = 'pretty'
+    end
+
+    def site_payload
+      {}
+    end
+
+    def converters
+      []
+    end
+  end
+end

--- a/test/dummy_site.rb
+++ b/test/dummy_site.rb
@@ -1,6 +1,6 @@
 module GuidesStyle18F
   class DummySite
-    attr_accessor :config, :layouts, :static_files, :collections
+    attr_accessor :config, :layouts, :static_files, :collections, :pages
     attr_accessor :permalink_style
 
     def initialize
@@ -8,6 +8,7 @@ module GuidesStyle18F
       @layouts = {}
       @static_files = []
       @collections = {}
+      @pages = []
       @permalink_style = 'pretty'
     end
 

--- a/test/flatten_url_namespace_test.rb
+++ b/test/flatten_url_namespace_test.rb
@@ -1,0 +1,30 @@
+require_relative '../lib/guides_style_18f/generator'
+
+require 'minitest/autorun'
+
+module GuidesStyle18F
+  class DummySite
+    attr_accessor :config, :layouts, :static_files, :collections
+
+    def initialize
+      @config = {}
+      @layouts = {}
+      @static_files = []
+      @collections = {}
+    end
+  end
+
+  class FlattenUrlNamespaceTest < ::Minitest::Test
+    attr_accessor :site, :generator
+
+    def setup
+      @site = DummySite.new
+      @generator = Generator.new
+    end
+
+    def test_empty_data
+      generator.generate(site)
+      assert_nil(site.collections['docs'])
+    end
+  end
+end

--- a/test/flatten_url_namespace_test.rb
+++ b/test/flatten_url_namespace_test.rb
@@ -1,30 +1,236 @@
 require_relative '../lib/guides_style_18f/generator'
+require_relative './dummy_collection'
+require_relative './dummy_page'
+require_relative './dummy_site'
 
+require 'jekyll/page'
 require 'minitest/autorun'
 
 module GuidesStyle18F
-  class DummySite
-    attr_accessor :config, :layouts, :static_files, :collections
-
-    def initialize
-      @config = {}
-      @layouts = {}
-      @static_files = []
-      @collections = {}
-    end
-  end
-
+  # rubocop:disable ClassLength
+  # rubocop:disable MethodLength
   class FlattenUrlNamespaceTest < ::Minitest::Test
     attr_accessor :site, :generator
+    attr_accessor :home_page, :foo_page, :bar_page, :baz_page
+    attr_accessor :quux_page, :xyzzy_page, :plugh_page, :all_docs
 
     def setup
       @site = DummySite.new
       @generator = Generator.new
+      @home_page = DummyPage.new(site, '/')
+      setup_pages
+      @all_docs = [
+        home_page,
+        foo_page, bar_page, baz_page,
+        quux_page, xyzzy_page, plugh_page
+      ]
+      setup_nav
+    end
+
+    def setup_pages
+      @foo_page = DummyPage.new(site, '/foo/')
+      @bar_page = DummyPage.new(site, '/foo/bar/')
+      @baz_page = DummyPage.new(site, '/foo/baz/')
+      @quux_page = DummyPage.new(site, '/quux/')
+      @xyzzy_page = DummyPage.new(site, '/quux/xyzzy/')
+      @plugh_page = DummyPage.new(site, '/quux/xyzzy/plugh/')
+    end
+
+    def setup_nav
+      site.config['navigation'] = [
+        { 'text' => 'Introduction' },
+        { 'url' => 'foo/',
+          'text' => 'Foo info',
+          'children' => [
+            { 'url' => 'bar/', 'text' => 'Bar info' },
+            { 'url' => 'baz/', 'text' => 'Baz info' },
+          ],
+        },
+        { 'url' => 'quux/',
+          'text' => 'Quux info',
+          'children' => [
+            { 'url' => 'xyzzy/',
+              'text' => 'Xyzzy info',
+              'children' => [
+                { 'url' => 'plugh/', 'text' => 'Plugh info' },
+              ],
+            },
+          ],
+        },
+      ]
     end
 
     def test_empty_data
       generator.generate(site)
       assert_nil(site.collections['docs'])
     end
+
+    # rubocop:disable AbcSize
+    def test_single_home_page
+      site.collections['pages'] = DummyCollection.new([home_page])
+      generator.generate(site)
+
+      assert_equal('/', home_page.data['permalink'])
+      assert_equal([{ 'url' => '/', 'text' => 'Introduction' }],
+        home_page.data['breadcrumbs'])
+
+      site.config['flat_namespace'] = true
+      assert_equal('/', home_page.data['permalink'])
+      assert_equal([{ 'url' => '/', 'text' => 'Introduction' }],
+        home_page.data['breadcrumbs'])
+    end
+
+    def test_two_pages
+      site.collections['pages'] = DummyCollection.new([home_page, foo_page])
+      generator.generate(site)
+
+      assert_equal('/', home_page.data['permalink'])
+      assert_equal('/foo/', foo_page.data['permalink'])
+
+      assert_equal([{ 'url' => '/', 'text' => 'Introduction' }],
+        home_page.data['breadcrumbs'])
+      assert_equal([{ 'url' => '/foo/', 'text' => 'Foo info' }],
+        foo_page.data['breadcrumbs'])
+
+      site.config['flat_namespace'] = true
+      assert_equal('/', home_page.data['permalink'])
+      assert_equal('/foo/', foo_page.data['permalink'])
+
+      assert_equal([{ 'url' => '/', 'text' => 'Introduction' }],
+        home_page.data['breadcrumbs'])
+      assert_equal([{ 'url' => '/foo/', 'text' => 'Foo info' }],
+        foo_page.data['breadcrumbs'])
+    end
+
+    def test_nested_namespace
+      site.collections['pages'] = DummyCollection.new(all_docs)
+      generator.generate(site)
+
+      assert_equal('/', home_page.data['permalink'])
+      assert_equal('/foo/', foo_page.data['permalink'])
+      assert_equal('/foo/bar/', bar_page.data['permalink'])
+      assert_equal('/foo/baz/', baz_page.data['permalink'])
+      assert_equal('/quux/', quux_page.data['permalink'])
+      assert_equal('/quux/xyzzy/', xyzzy_page.data['permalink'])
+      assert_equal('/quux/xyzzy/plugh/', plugh_page.data['permalink'])
+
+      assert_equal(
+        [
+          { 'url' => '/', 'text' => 'Introduction' },
+        ],
+        home_page.data['breadcrumbs'])
+      assert_equal(
+        [
+          { 'url' => '/foo/', 'text' => 'Foo info' },
+        ],
+        foo_page.data['breadcrumbs'])
+      assert_equal(
+        [
+          { 'url' => '/foo/', 'text' => 'Foo info' },
+          { 'url' => '/foo/bar/', 'text' => 'Bar info' },
+        ],
+        bar_page.data['breadcrumbs'])
+      assert_equal(
+        [
+          { 'url' => '/foo/', 'text' => 'Foo info' },
+          { 'url' => '/foo/baz/', 'text' => 'Baz info' },
+        ],
+        baz_page.data['breadcrumbs'])
+      assert_equal(
+        [
+          { 'url' => '/quux/', 'text' => 'Quux info' },
+        ],
+        quux_page.data['breadcrumbs'])
+      assert_equal(
+        [
+          { 'url' => '/quux/', 'text' => 'Quux info' },
+          { 'url' => '/quux/xyzzy/', 'text' => 'Xyzzy info' },
+        ],
+        xyzzy_page.data['breadcrumbs'])
+      assert_equal(
+        [
+          { 'url' => '/quux/', 'text' => 'Quux info' },
+          { 'url' => '/quux/xyzzy/', 'text' => 'Xyzzy info' },
+          { 'url' => '/quux/xyzzy/plugh/', 'text' => 'Plugh info' },
+        ],
+        plugh_page.data['breadcrumbs'])
+    end
+
+    def test_flat_namespace
+      site.config['flat_namespace'] = true
+      site.collections['pages'] = DummyCollection.new(all_docs)
+      generator.generate(site)
+
+      assert_equal('/', home_page.data['permalink'])
+      assert_equal('/foo/', foo_page.data['permalink'])
+      assert_equal('/bar/', bar_page.data['permalink'])
+      assert_equal('/baz/', baz_page.data['permalink'])
+      assert_equal('/quux/', quux_page.data['permalink'])
+      assert_equal('/xyzzy/', xyzzy_page.data['permalink'])
+      assert_equal('/plugh/', plugh_page.data['permalink'])
+
+      assert_equal(
+        [
+          { 'url' => '/', 'text' => 'Introduction' },
+        ],
+        home_page.data['breadcrumbs'])
+      assert_equal(
+        [
+          { 'url' => '/foo/', 'text' => 'Foo info' },
+        ],
+        foo_page.data['breadcrumbs'])
+      assert_equal(
+        [
+          { 'url' => '/foo/', 'text' => 'Foo info' },
+          { 'url' => '/bar/', 'text' => 'Bar info' },
+        ],
+        bar_page.data['breadcrumbs'])
+      assert_equal(
+        [
+          { 'url' => '/foo/', 'text' => 'Foo info' },
+          { 'url' => '/baz/', 'text' => 'Baz info' },
+        ],
+        baz_page.data['breadcrumbs'])
+      assert_equal(
+        [
+          { 'url' => '/quux/', 'text' => 'Quux info' },
+        ],
+        quux_page.data['breadcrumbs'])
+      assert_equal(
+        [
+          { 'url' => '/quux/', 'text' => 'Quux info' },
+          { 'url' => '/xyzzy/', 'text' => 'Xyzzy info' },
+        ],
+        xyzzy_page.data['breadcrumbs'])
+      assert_equal(
+        [
+          { 'url' => '/quux/', 'text' => 'Quux info' },
+          { 'url' => '/xyzzy/', 'text' => 'Xyzzy info' },
+          { 'url' => '/plugh/', 'text' => 'Plugh info' },
+        ],
+        plugh_page.data['breadcrumbs'])
+    end
+
+    def test_raise_if_collisions_in_flat_namespace
+      site.config['flat_namespace'] = true
+      colliding_docs = [
+        DummyPage.new(site, '/foo/'),
+        DummyPage.new(site, '/foo/bar/'),
+        DummyPage.new(site, '/foo/baz/'),
+        DummyPage.new(site, '/bar/'),
+        DummyPage.new(site, '/bar/baz/'),
+      ]
+      site.collections['pages'] = DummyCollection.new(colliding_docs)
+      exception = assert_raises(StandardError) do
+        generator.generate(site)
+      end
+      assert_equal("collisions in flattened namespace between\n" \
+        "  /bar/: /foo/bar/, /bar/\n" \
+        '  /baz/: /foo/baz/, /bar/baz/',
+        exception.message)
+    end
   end
+  # rubocop:enable AbcSize
+  # rubocop:enable MethodLength
+  # rubocop:enable ClassLength
 end


### PR DESCRIPTION
This enables documents to be structured hierarchically in the `_pages` directory, yet have their URLs and breadcrumbs all be rooted at `{{ site.baseurl }}` rather than maintaining a hierarchical URL structure. It is enabled by setting `flat_namespace: true` in `_config.yml`. It performs collision checking, i.e. enabling this with a structure that contains `/foo/bar/` and `/baz/bar/` will raise an error, since both URLs map to `/bar/`.

cc: @ccostino @ertzeid @andrewmaier @mtorres253 