### PR TITLE
[WIP] Generate navigation pages that redirect to home page IDs

### DIFF
--- a/lib/guides_style_18f/breadcrumbs.rb
+++ b/lib/guides_style_18f/breadcrumbs.rb
@@ -5,7 +5,9 @@ module GuidesStyle18F
   class Breadcrumbs
     def self.generate(site, docs)
       breadcrumbs = create_breadcrumbs(site)
-      docs.each { |page| page.data['breadcrumbs'] = breadcrumbs[page.url] }
+      docs.each do |page|
+        page.data['breadcrumbs'] = breadcrumbs[page.permalink || page.url]
+      end
     end
 
     def self.create_breadcrumbs(site)

--- a/lib/guides_style_18f/generated_pages.rb
+++ b/lib/guides_style_18f/generated_pages.rb
@@ -1,0 +1,38 @@
+require_relative './layouts'
+
+module GuidesStyle18F
+  class GeneratedPages
+    DEFAULT_LAYOUT = 'guides_style_18f_generated_home_redirect'
+
+    def self.generate_pages_from_navigation_data(site)
+      layout = site.config['generate_nodes']
+      return if layout.nil? || layout == false
+      layout = DEFAULT_LAYOUT if layout == true
+      nav_data = site.config['navigation']
+      generate_pages_from_generated_nodes(site, layout, nav_data, '/')
+    end
+
+    def self.generate_pages_from_generated_nodes(
+      site, layout, nav_data, parent_url)
+      (nav_data || []).select { |nav| nav['generated'] }.each do |nav|
+        site.pages << GeneratedPage.new(site, layout, nav, parent_url)
+        children = nav['children']
+        next_url = parent_url + nav['url']
+        generate_pages_from_generated_nodes(site, layout, children, next_url)
+      end
+    end
+  end
+
+  class GeneratedPage < ::Jekyll::Page
+    def initialize(site, layout, nav, parent_url)
+      @site = site
+      @name = 'index.html'
+
+      process(@name)
+      @data = {}
+      data['title'] = nav['text']
+      data['permalink'] = parent_url + nav['url']
+      data['layout'] = layout
+    end
+  end
+end

--- a/lib/guides_style_18f/generator.rb
+++ b/lib/guides_style_18f/generator.rb
@@ -2,6 +2,7 @@
 
 require_relative './assets'
 require_relative './breadcrumbs'
+require_relative './generated_pages'
 require_relative './layouts'
 require_relative './namespace_flattener'
 
@@ -12,6 +13,7 @@ module GuidesStyle18F
     def generate(site)
       Layouts.register(site)
       Assets.copy_to_site(site)
+      GeneratedPages.generate_pages_from_navigation_data(site)
       pages = site.collections['pages']
       docs = (pages.nil? ? [] : pages.docs) + site.pages
       Breadcrumbs.generate(site, docs)

--- a/lib/guides_style_18f/includes/home-redirect.html
+++ b/lib/guides_style_18f/includes/home-redirect.html
@@ -1,0 +1,8 @@
+---
+---
+<!DOCTYPE html>
+<html>
+<head><meta http-equiv="refresh" content="0;URL='{{ site.baseurl }}/#{{ page.title | slugify }}'">
+</head>
+<body></body>
+</html>

--- a/lib/guides_style_18f/layouts.rb
+++ b/lib/guides_style_18f/layouts.rb
@@ -7,11 +7,13 @@ module GuidesStyle18F
   # We have to essentially recreate the ::Jekyll::Layout constructor to loosen
   # the default restriction that layouts be included in the site source.
   class Layouts < ::Jekyll::Layout
+    LAYOUTS_DIR = File.join(File.dirname(__FILE__), 'layouts')
+
     private_class_method :new
 
-    def initialize(site, layout_file)
+    def initialize(site, subdir, layout_file)
       @site = site
-      @base = File.join File.dirname(__FILE__), 'layouts'
+      @base = File.join(LAYOUTS_DIR, subdir)
       @name = "#{layout_file}.html"
       @path = File.join @base, @name
       parse_content_and_data File.join(@base, name)
@@ -20,7 +22,7 @@ module GuidesStyle18F
 
     def parse_content_and_data(file_path)
       self.data = {}
-      self.content = File.read file_path
+      self.content = File.read(file_path)
 
       front_matter_pattern = /^(---\n.*)---\n/m
       front_matter_match = front_matter_pattern.match content
@@ -32,7 +34,9 @@ module GuidesStyle18F
     private :parse_content_and_data
 
     def self.register(site)
-      site.layouts['guides_style_18f_default'] = new site, 'default'
+      site.layouts['guides_style_18f_default'] = new(site, '', 'default')
+      site.layouts['guides_style_18f_generated_home_redirect'] = new(
+        site, 'generated', 'home-redirect')
     end
   end
 end

--- a/lib/guides_style_18f/layouts/generated/home-redirect.html
+++ b/lib/guides_style_18f/layouts/generated/home-redirect.html
@@ -1,5 +1,3 @@
----
----
 <!DOCTYPE html>
 <html>
 <head><meta http-equiv="refresh" content="0;URL='{{ site.baseurl }}/#{{ page.title | slugify }}'">

--- a/lib/guides_style_18f/namespace_flattener.rb
+++ b/lib/guides_style_18f/namespace_flattener.rb
@@ -11,8 +11,9 @@ module GuidesStyle18F
     end
 
     def self.flatten_page_urls(page, flat_to_orig)
-      flattened_url = flat_url(page.url)
-      (flat_to_orig[flattened_url] ||= []) << page.url
+      orig_url = page.permalink || page.url
+      flattened_url = flat_url(orig_url)
+      (flat_to_orig[flattened_url] ||= []) << orig_url
       page.data['permalink'] = flattened_url
       (page.data['breadcrumbs'] || []).each do |crumb|
         crumb['url'] = flat_url(crumb['url'])


### PR DESCRIPTION
Based on #45 and #46, which must go in first. Will create a corresponding 18F/handbook PR that, when combined with the changes in this branch, produce a functional Handbook site where all page URLs are direct children of `site.baseurl` and the pages generated from generated `navigation:` items will redirect to a URL fragment on the home page.

Note that as I originally write this, #45 and #46 have automated tests, but I need to add tests for the changes added in this PR.

cc: @andrewmaier @ccostino @ertzeid @mtorres253 