### PR TITLE
fix for private-eye

### DIFF
--- a/assets/js/18f-guide.js
+++ b/assets/js/18f-guide.js
@@ -10,9 +10,16 @@ $(function() {
       'https://docs.google.com',
       'https://drive.google.com',
       'https://github.com/18F/Accessibility_Reviews',
+      'https://github.com/18F/blog-drafts',
+      'https://github.com/18F/codereviews',
       'https://github.com/18F/DevOps',
       'https://github.com/18F/handbook',
-      'https://github.com/18F/writing-lab'
+      'https://github.com/18F/Infrastructure',
+      'https://github.com/18F/staffing-and-resources',
+      'https://github.com/18F/team-api.18f.gov',
+      'https://github.com/18F/writing-lab',
+      'https://gsa.my.salesforce.com',
+      'https://insite.gsa.gov'
     ]
   });
 });

--- a/assets/js/vendor/private-eye-1.0.0.js
+++ b/assets/js/vendor/private-eye-1.0.0.js
@@ -1,0 +1,24 @@
+// https://github.com/18F/private-eye
+(function() {
+  'use strict';
+
+  var PrivateEye = function(opts) {
+    var styles = document.createElement('style');
+    styles.innerHTML = 'a.private-link::after { content: "\\1F512"; font-size: 0.75em; vertical-align: top; }';
+    document.body.appendChild(styles);
+
+    opts.ignoreUrls.forEach(function(url) {
+      var anchors = document.querySelectorAll('a[href*="' + url + '"]');
+      Array.prototype.forEach.call(anchors, function(anchor) {
+        anchor.className += ' private-link';
+        anchor.title = "This is a link to a private site, which may or may not be accessible to you.";
+      });
+    });
+  };
+
+  if (typeof module === 'object' && typeof module.exports === 'object') {
+    module.exports = PrivateEye;
+  } else {
+    window.PrivateEye = PrivateEye;
+  }
+})();

--- a/lib/guides_style_18f/includes/header.html
+++ b/lib/guides_style_18f/includes/header.html
@@ -3,6 +3,7 @@
   <meta charset="utf-8">
   <title>{{ page.title }} - {{ site.name }}</title>
   <meta name="viewport" content="width=device-width">
+  <!-- If any of the file paths after guides_style_18f_asset_root change, the old ones need to stay in place. See https://github.com/18F/pages-server/issues/55 for more information. -->
   <link rel="shortcut icon" type="image/ico" href="{% guides_style_18f_asset_root %}/assets/favicons/favicon.ico" />
   <link rel="icon" type="image/png" href="{% guides_style_18f_asset_root %}/assets/favicons/favicon.png" />
   <link rel="apple-touch-icon-precomposed" href="{% guides_style_18f_asset_root %}/assets/favicons/18f-center-57.png" />

--- a/lib/guides_style_18f/includes/scripts.html
+++ b/lib/guides_style_18f/includes/scripts.html
@@ -1,3 +1,4 @@
+<!-- If any of the file paths after guides_style_18f_asset_root change, the old ones need to stay in place. See https://github.com/18F/pages-server/issues/55 for more information. -->
 <script src="{% guides_style_18f_asset_root %}/assets/js/vendor/jquery-1.11.2.min.js"></script>
 <script src="{% guides_style_18f_asset_root %}/assets/js/accordion.js"></script>
 <script src="{% guides_style_18f_asset_root %}/assets/js/vendor/private-eye-1.1.0.js"></script>


### PR DESCRIPTION
Re-adds the old version of private-eye back in, which will allow us to revert https://github.com/18F/guides-template/pull/82 without breaking sites using version <= 0.4.3 of this gem. Basically, without https://github.com/18F/pages-server/issues/55 being done, we can't remove/change any asset paths in this repository.
 
/cc @wslack