### PR TITLE
Simplify size and animation of sidebar links

### DIFF
--- a/lib/guides_style_18f/sass/_guides_style_18f_main.scss
+++ b/lib/guides_style_18f/sass/_guides_style_18f_main.scss
@@ -205,7 +205,6 @@ Navigation
 .sidebar-nav li {
   list-style: none;
   border-bottom: 1px solid #babbbd;
-  font-size: 1em;
   line-height: 1.4;
   overflow: hidden;
 }

--- a/lib/guides_style_18f/sass/_guides_style_18f_main.scss
+++ b/lib/guides_style_18f/sass/_guides_style_18f_main.scss
@@ -184,6 +184,7 @@ Navigation
 .sidebar-nav a:link,
 .sidebar-nav a:visited {
   border-bottom: none;
+  border-left: 4px solid transparent;
   color: #74767B;
 }
 

--- a/lib/guides_style_18f/sass/_guides_style_18f_main.scss
+++ b/lib/guides_style_18f/sass/_guides_style_18f_main.scss
@@ -205,7 +205,8 @@ Navigation
 .sidebar-nav li {
   list-style: none;
   border-bottom: 1px solid #babbbd;
-  font-size: 1.125em;
+  font-size: 1em;
+  line-height: 1.4;
   overflow: hidden;
 }
 


### PR DESCRIPTION
The large size and animated push-in effect on the sidebar links was distracting and didn't fit with the type scale of the rest of the page. I modified the link style so the blue bar would animate, but not push in the text, and I reduced the size of the link text and tightened the leading to read more smoothly, especially when the sidebar text breaks over multiple lines.
