### PR TITLE
resets max height at a high number to preserve animation

### DIFF
--- a/lib/guides_style_18f/sass/_guides_style_18f_main.scss
+++ b/lib/guides_style_18f/sass/_guides_style_18f_main.scss
@@ -221,6 +221,7 @@ Navigation
     display: block;
     font-size: 14px;
     max-height: initial;
+    max-height: 4000px;
     overflow: auto;
     opacity: 1;
     position: relative;


### PR DESCRIPTION
Another fix for: https://github.com/18F/frontend/issues/111

* Sets max-height to a very high number so it animates properly when opening/closing the sidenav menu

