### PR TITLE
Remove 18f-pages branch creation

### DIFF
--- a/lib/guides_style_18f/repository.rb
+++ b/lib/guides_style_18f/repository.rb
@@ -52,7 +52,6 @@ module GuidesStyle18F
 
   GIT_COMMANDS = {
     'Creating a new git repository.' => 'git init',
-    'Creating 18f-pages branch.' => 'git checkout -b 18f-pages',
     'Adding files for initial commit.' => 'git add .',
   }
 

--- a/test/repository_test.rb
+++ b/test/repository_test.rb
@@ -196,8 +196,6 @@ Removing `:create_repo` command from the `./go` script.
 Removing old git repository.
 Creating a new git repository.
 Initialized empty Git repository in %s/.git/
-Creating 18f-pages branch.
-Switched to a new branch '18f-pages'
 Adding files for initial commit.
 All done! Run 'git commit' to create your first commit.
 LOG_TAIL


### PR DESCRIPTION
This commit removes the creation of the 18f-pages branch from the `create_new_git_repository`. Now that Federalist is the new home for 18F Pages, there is no need to create this branch.

Ref 18F/guides-template#90