### PR TITLE
Pin Jekyll version

### DIFF
--- a/guides-style-18f.gemspec
+++ b/guides-style-18f.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files -z *.md lib assets`.split("\x0")
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename f }
 
-  s.add_runtime_dependency 'jekyll'
+  s.add_runtime_dependency 'jekyll', '~>3.1'
   s.add_runtime_dependency 'jekyll_pages_api'
   s.add_runtime_dependency 'jekyll_pages_api_search'
   s.add_runtime_dependency 'sass'


### PR DESCRIPTION
This pins the Jekyll version to `3.1` to get around inconsistencies with the [18F Jekyll search gem](https://github.com/18F/jekyll_pages_api_search/). This shouldn't be considered a long-term fix, but will allow people to upgrade the gem without causing issues.