### PR TITLE
remove duplicate href attribute in homepage link

### DIFF
--- a/lib/guides_style_18f/includes/header.html
+++ b/lib/guides_style_18f/includes/header.html
@@ -5,7 +5,7 @@
     <button class="usa-menu-btn">Menu</button>
     <div class="usa-logo" id="logo">
       <em class="usa-logo-text">
-        <a href="#" accesskey="1" title="Home" aria-label="Home" href="{{ site.baseurl }}/">{{ site.name }}</a>
+        <a accesskey="1" title="Home" aria-label="Home" href="{{ site.baseurl }}/">{{ site.name }}</a>
       </em>
     </div>
   </div>


### PR DESCRIPTION
In other words, fix clicking the logo not actually taking you to the `baseurl`.