### PR TITLE
Header/footer HTML fixes

### DIFF
--- a/lib/guides_style_18f/includes/banner.html
+++ b/lib/guides_style_18f/includes/banner.html
@@ -1,6 +1,6 @@
 <div class="usa-banner">
   <div class="usa-accordion">
-    <header class="usa-banner-header">
+    <div class="usa-banner-header">
       <div class="usa-grid usa-banner-inner">
       <img src="{{ site.baseurl }}/assets/uswds/img/favicons/favicon-57.png" alt="U.S. flag">
       <p>An official website of the United States government</p>
@@ -9,7 +9,7 @@
         <span class="usa-banner-button-text">Here's how you know</span>
       </button>
       </div>
-    </header>
+    </div>
     <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
       <div class="usa-banner-guidance-gov usa-width-one-half">
         <img class="usa-banner-icon usa-media_block-img" src="{{ site.baseurl }}/assets/uswds/img/icon-dot-gov.svg" alt="Dot gov">

--- a/lib/guides_style_18f/includes/footer.html
+++ b/lib/guides_style_18f/includes/footer.html
@@ -33,14 +33,15 @@
         </ul>
       </nav>
       <div class="usa-width-one-third">
-      <ul class="usa-unstyled-list">
-        <li class="usa-footer-primary-content">
-            Maintained by <a href="{{ site.author.url }}">{{ site.author.name }}</a>
-        </li>
-        <li class="usa-footer-primary-content">
-            Hosted by <a href="https://federalist.fr.cloud.gov/">Federalist</a>
-        </li>
-      </ul>
+        <ul class="usa-unstyled-list">
+          <li class="usa-footer-primary-content">
+              Maintained by <a href="{{ site.author.url }}">{{ site.author.name }}</a>
+          </li>
+          <li class="usa-footer-primary-content">
+              Hosted by <a href="https://federalist.fr.cloud.gov/">Federalist</a>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </footer>

--- a/lib/guides_style_18f/layouts/default.html
+++ b/lib/guides_style_18f/layouts/default.html
@@ -22,7 +22,7 @@
 
     </div> <!-- /.container -->
 
+    {% guides_style_18f_include analytics.html %}
+    {% guides_style_18f_include scripts.html %}
   </body>
-{% guides_style_18f_include analytics.html %}
-{% guides_style_18f_include scripts.html %}
 </html>


### PR DESCRIPTION
Two HTML fixes, as noted by #91:
- Changed USA banner element to a div instead of a header to avoid nested header error
- Added missing closing div tag

The complaint about an open script tag is invalid, as there is a closing script tag after the GA JS block. If there are thoughts about how to get the linter to not throw an error, I'd love to hear 'em!