### PR TITLE
Only include search assets if site has configured jekyll_pages_api_search

### DIFF
--- a/lib/guides_style_18f/includes/scripts.html
+++ b/lib/guides_style_18f/includes/scripts.html
@@ -5,4 +5,6 @@
 <script src="{% guides_style_18f_asset_root %}/assets/js/18f-guide.js"></script>{% for script in site.scripts %}
 <script src="{{ site.baseurl }}/{{ script }}"></script>{% endfor %}{% for script in page.scripts %}
 <script src="{{ site.baseurl }}/{{ script }}"></script>{% endfor %}
-{% jekyll_pages_api_search_load %}
+{% if site.jekyll_pages_api_search %}
+  {% jekyll_pages_api_search_load %}
+{% endif %}


### PR DESCRIPTION
Fixes #96

This PR amends `scripts.html` to include `jekyll_pages_api_search`'s javascript assets only if the site has defined settings for `jekyll_pages_api_search` in its configuration (ie, in `_config.yml`).

This alleviates the missing `search-bundle.js` `404` that gets thrown when a site has not configured `jekyll_pages_api_search`.