### PR TITLE
Uncomment the markup that links favicons/icons

### DIFF
--- a/lib/guides_style_18f/includes/head.html
+++ b/lib/guides_style_18f/includes/head.html
@@ -49,13 +49,13 @@
   {% endif %}
 
   <!-- If any of the file paths after guides_style_18f_asset_root change, the old ones need to stay in place. See https://github.com/18F/pages-server/issues/55 for more information. -->
-  <!--<link rel="shortcut icon" type="image/ico" href="{% guides_style_18f_asset_root %}/assets/favicons/favicon.ico" />
+  <link rel="shortcut icon" type="image/ico" href="{% guides_style_18f_asset_root %}/assets/favicons/favicon.ico" />
   <link rel="icon" type="image/png" href="{% guides_style_18f_asset_root %}/assets/favicons/favicon.png" />
   <link rel="apple-touch-icon-precomposed" href="{% guides_style_18f_asset_root %}/assets/favicons/18f-center-57.png" />
   <link rel="apple-touch-icon-precomposed" sizes="72x72" href="{% guides_style_18f_asset_root %}/assets/favicons/18f-center-72.png" />
   <link rel="apple-touch-icon-precomposed" sizes="114x114" href="{% guides_style_18f_asset_root %}/assets/favicons/18f-center-114.png" />
   <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{% guides_style_18f_asset_root %}/assets/favicons/18f-center-144.png"/>
-  <link rel="icon" type="image/png" sizes="192x192" href="{% guides_style_18f_asset_root %}/assets/favicons/18f-center-192.png" />-->
+  <link rel="icon" type="image/png" sizes="192x192" href="{% guides_style_18f_asset_root %}/assets/favicons/18f-center-192.png" />
   <link rel="stylesheet" href="{% guides_style_18f_asset_root %}/assets/uswds/css/uswds.min.css">
   <link rel="stylesheet" href="{% guides_style_18f_asset_root %}/assets/css/main.css">
   {% for style in site.styles %}


### PR DESCRIPTION
Fixes #98. I think maybe the icons `<link>`s were probably just accidentally commented out, but I'm unsure.