### PR TITLE
add support for search.gov

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,46 @@ navigation:
     internal: true
 ```
 
+### Search
+
+There are two options for search.
+
+#### jekyll_pages_api_search
+
+Pros:
+
+* Generates a search index locally, which has the advantage of being self-contained. This means you can easily test search locally, on a staging site, etc.
+* Search results are shown in your site's layout
+
+Cons:
+
+* Slows down your build
+
+Usage: see [the instructions](https://github.com/18F/jekyll_pages_api_search#installation).
+
+#### search.gov
+
+Pros:
+
+* A hosted service, so your site has fewer moving parts.
+* A more full-featured search engine
+* Search results show a preview of the text on the page, with highlighted term(s)
+* Provides analytics
+
+Cons:
+
+* You need to register your site
+* Can't test search results locally
+
+Usage:
+
+1. Register your site at [search.gov](https://search.gov/).
+1. Add the following to your `_config.yml`:
+
+    ```yaml
+    search_gov_handle: <your Site Handle from the search.gov Settings page>
+    ```
+
 ### Development
 
 First, choose a Jekyll site you'd like to use to view the impact of your

--- a/lib/guides_style_18f/includes/header.html
+++ b/lib/guides_style_18f/includes/header.html
@@ -36,11 +36,26 @@
         <ul class="usa-unstyled-list usa-nav-secondary-links">
           {% if site.jekyll_pages_api_search %}
           <li>
-          <div role="search" class="usa-search usa-search-small">
-            {% jekyll_pages_api_search_interface %}
-          </div>
+            <div role="search" class="usa-search usa-search-small">
+              {% jekyll_pages_api_search_interface %}
+            </div>
           </li>
-        {% endif %}
+          {% endif %}
+          {% if site.search_gov_handle %}
+          <li>
+            <div role="search" class="usa-search usa-search-small">
+              <form accept-charset="UTF-8" action="https://search.usa.gov/search" id="search_form" class="search-interface" method="get">
+                <input name="utf8" type="hidden" value="&#x2713;" />
+                <input id="affiliate" name="affiliate" type="hidden" value="{{ site.search_gov_handle }}" />
+                <label>
+                  <span class="label-text">Search</span>
+                  <input autocomplete="off" type="search" id="query" class="usagov-search-autocomplete" name="query" placeholder="Search">
+                </label>
+                <button name="commit" type="submit">Search</button>
+              </form>
+            </div>
+          </li>
+          {% endif %}
           {% if site.back_link %}
           <li>
             <a href="{{ site.back_link.url }}">{{ site.back_link.text }}</a>

--- a/lib/guides_style_18f/includes/scripts.html
+++ b/lib/guides_style_18f/includes/scripts.html
@@ -8,3 +8,16 @@
 {% if site.jekyll_pages_api_search %}
   {% jekyll_pages_api_search_load %}
 {% endif %}
+{% if site.search_gov_handle %}
+<script type="text/javascript">
+//<![CDATA[
+      var usasearch_config = { siteHandle: "{{ site.search_gov_handle }}" };
+
+      var script = document.createElement("script");
+      script.type = "text/javascript";
+      script.src = "//search.usa.gov/javascripts/remote.loader.js";
+      document.getElementsByTagName("head")[0].appendChild(script);
+
+//]]>
+</script>
+{% endif %}


### PR DESCRIPTION
Closes #108.

Also documented usage of [jekyll_pages_api_search](https://github.com/18F/jekyll_pages_api_search).

/cc https://github.com/18F/federalist-docs/pull/142